### PR TITLE
Feature/3

### DIFF
--- a/constants/dataValidationMessage.js
+++ b/constants/dataValidationMessage.js
@@ -12,3 +12,16 @@ exports.SCHEMA_MESSAGE = {
   habitActivationError: "Activation information is required.",
   catImageUrlError: "Image link for a single cat is required.",
 };
+
+exports.TOKEN_MESSAGE = {
+  tokenError: "Invalid token from client.",
+  emptyTokenError: "Empty token request from client",
+};
+
+exports.AUTH_MESSAGE = {
+  invalidUser: "Invalid user",
+};
+
+exports.COMMON_MESSAGE = {
+  invalidServerError: "Invalid server error",
+};

--- a/constants/dataValidationMessage.js
+++ b/constants/dataValidationMessage.js
@@ -2,6 +2,7 @@ exports.SCHEMA_MESSAGE = {
   userEmailUniqueError: "Email should be unique.",
   userEmailRequiredError: "Email information is required.",
   userNameError: "Name information is required.",
+  habitAuthorError: "Author information is required.",
   habitTitleError: "Title information is required.",
   habitDateListDateError: "Date information for key is required.",
   habitCheckedError: "Checked status is required.",

--- a/constants/numbers.js
+++ b/constants/numbers.js
@@ -1,0 +1,4 @@
+exports.TIME_NUMBERS = {
+  accessTokenExpiredTime: 24 * 60 * 60 * 1000,
+  checkTimeForActiveness: 24 * 60 * 60 * 1000,
+};

--- a/models/Habit.js
+++ b/models/Habit.js
@@ -26,10 +26,6 @@ const HabitSchema = new Schema({
       },
     },
   ],
-  endDate: {
-    type: String,
-    required: [true, SCHEMA_MESSAGE.habitEndDateError],
-  },
   catImage: {
     catType: {
       type: Schema.Types.ObjectId,
@@ -40,10 +36,6 @@ const HabitSchema = new Schema({
       type: Number,
       required: [true, SCHEMA_MESSAGE.habitCatStatusError],
     },
-  },
-  isActive: {
-    type: Boolean,
-    required: [true, SCHEMA_MESSAGE.habitActivationError],
   },
 });
 

--- a/models/Habit.js
+++ b/models/Habit.js
@@ -4,6 +4,11 @@ const { Schema } = mongoose;
 const { SCHEMA_MESSAGE } = require("../constants/dataValidationMessage");
 
 const HabitSchema = new Schema({
+  author: {
+    type: Schema.Types.ObjectId,
+    required: [true, SCHEMA_MESSAGE.habitAuthorError],
+    ref: "User",
+  },
   title: {
     type: String,
     required: [true, SCHEMA_MESSAGE.habitTitleError],
@@ -25,19 +30,17 @@ const HabitSchema = new Schema({
     type: String,
     required: [true, SCHEMA_MESSAGE.habitEndDateError],
   },
-  catImage: [
-    {
-      catType: {
-        type: Schema.Types.ObjectId,
-        required: [true, SCHEMA_MESSAGE.habitCatTypeError],
-        ref: "CatImage",
-      },
-      catStatus: {
-        type: Number,
-        required: [true, SCHEMA_MESSAGE.habitCatStatusError],
-      },
+  catImage: {
+    catType: {
+      type: Schema.Types.ObjectId,
+      required: [true, SCHEMA_MESSAGE.habitCatTypeError],
+      ref: "CatImage",
     },
-  ],
+    catStatus: {
+      type: Number,
+      required: [true, SCHEMA_MESSAGE.habitCatStatusError],
+    },
+  },
   isActive: {
     type: Boolean,
     required: [true, SCHEMA_MESSAGE.habitActivationError],

--- a/models/sampleHabit.json
+++ b/models/sampleHabit.json
@@ -1,0 +1,82 @@
+[
+  {
+    "author": "621a78a7725ac002636cf6c6",
+    "title": "물 800ml 마시기",
+    "dateList": [
+      {
+        "date": "2022-02-25T00:00:00.099Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-26T00:00:00.099Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-27T00:00:00.099Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-28T00:00:00.099Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-03-01T00:00:00.099Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-03-02T00:00:00.099Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-03-03T00:00:00.099Z",
+        "isChecked": false
+      }
+    ],
+    "endDate": "2022-03-03T00:00:00.099Z",
+    "catImage": {
+      "catType": "621bbb3c2a3a3ca6871c6e22",
+      "catStatus": 2
+    },
+    "isActive": true
+  },
+  {
+    "author": "621a78a7725ac002636cf6c6",
+    "title": "비타민D 약 먹기",
+    "dateList": [
+      {
+        "date": "2022-02-01T00:00:00.099Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-02T00:00:00.099Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-03T00:00:00.099Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-04T00:00:00.099Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-05T00:00:00.099Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-06T00:00:00.099Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-07T00:00:00.099Z",
+        "isChecked": true
+      }
+    ],
+    "endDate": "2022-02-07T00:00:00.099Z",
+    "catImage": {
+      "catType": "621bbb3c2a3a3ca6871c6e24",
+      "catStatus": 4
+    },
+    "isActive": false
+  }
+]

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -4,6 +4,6 @@ const router = express.Router();
 const authController = require("./controllers/auth");
 const verifyGoogleIdToken = require("./middleware/verifyGoogleIdToken");
 
-router.get("/login", verifyGoogleIdToken, authController.getLogin);
+router.post("/login", verifyGoogleIdToken, authController.getLogin);
 
 module.exports = router;

--- a/routes/controllers/auth.js
+++ b/routes/controllers/auth.js
@@ -2,13 +2,15 @@ const createError = require("http-errors");
 const jwt = require("jsonwebtoken");
 
 const authService = require("../services/auth");
+const { TIME_NUMBERS } = require("../../constants/numbers");
+const { COMMON_MESSAGE } = require("../../constants/dataValidationMessage");
 
 exports.getLogin = async (req, res, next) => {
   try {
     const { id, name } = await authService.createUser(req.userInfo);
 
     const accessToken = jwt.sign({ id }, process.env.SECRET_KEY, {
-      expiresIn: 24 * 60 * 60 * 1000,
+      expiresIn: TIME_NUMBERS.accessTokenExpiredTime,
     });
 
     res.json({
@@ -19,7 +21,9 @@ exports.getLogin = async (req, res, next) => {
       token: accessToken,
     });
   } catch (err) {
-    const error = createError(500, err, { message: "Invalid Server Error" });
+    const error = createError(500, err, {
+      message: COMMON_MESSAGE.invalidServerError,
+    });
     next(error);
   }
 };

--- a/routes/controllers/habit.js
+++ b/routes/controllers/habit.js
@@ -3,12 +3,16 @@ const { ObjectId } = mongoose.Types;
 const createError = require("http-errors");
 
 const habitService = require("../services/habit");
+const {
+  AUTH_MESSAGE,
+  COMMON_MESSAGE,
+} = require("../../constants/dataValidationMessage");
 
 exports.getHabitList = async (req, res, next) => {
   const { userId } = req.params;
 
   if (!ObjectId.isValid(userId)) {
-    const error = createError(400, { message: "Invalid User" });
+    const error = createError(400, { message: AUTH_MESSAGE.invalidUser });
     next(error);
 
     return;
@@ -21,7 +25,9 @@ exports.getHabitList = async (req, res, next) => {
       habitList: targetHabitList,
     });
   } catch (err) {
-    const error = createError(500, err, { message: "Invalid Server Error" });
+    const error = createError(500, err, {
+      message: COMMON_MESSAGE.invalidServerError,
+    });
     next(error);
   }
 };

--- a/routes/controllers/habit.js
+++ b/routes/controllers/habit.js
@@ -18,7 +18,7 @@ exports.getHabitList = async (req, res, next) => {
     const targetHabitList = await habitService.getHabitList(userId);
 
     res.json({
-      result: "good",
+      habitList: targetHabitList,
     });
   } catch (err) {
     const error = createError(500, err, { message: "Invalid Server Error" });

--- a/routes/controllers/habit.js
+++ b/routes/controllers/habit.js
@@ -1,0 +1,27 @@
+const mongoose = require("mongoose");
+const { ObjectId } = mongoose.Types;
+const createError = require("http-errors");
+
+const habitService = require("../services/habit");
+
+exports.getHabitList = async (req, res, next) => {
+  const { userId } = req.params;
+
+  if (!ObjectId.isValid(userId)) {
+    const error = createError(400, { message: "Invalid User" });
+    next(error);
+
+    return;
+  }
+
+  try {
+    const targetHabitList = await habitService.getHabitList(userId);
+
+    res.json({
+      result: "good",
+    });
+  } catch (err) {
+    const error = createError(500, err, { message: "Invalid Server Error" });
+    next(error);
+  }
+};

--- a/routes/habit.js
+++ b/routes/habit.js
@@ -1,9 +1,9 @@
 const express = require("express");
 const router = express.Router();
 
-router.get("/:userId", (req, res, next) => {
-  console.log(req);
-});
+const habitController = require("../routes/controllers/habit");
+
+router.get("/:userId", habitController.getHabitList);
 
 router.post("/:userId/habit", (req, res, next) => {
   console.log(req);

--- a/routes/habit.js
+++ b/routes/habit.js
@@ -2,8 +2,9 @@ const express = require("express");
 const router = express.Router();
 
 const habitController = require("../routes/controllers/habit");
+const verifyToken = require("./middleware/verifyToken");
 
-router.get("/:userId", habitController.getHabitList);
+router.get("/:userId", verifyToken, habitController.getHabitList);
 
 router.post("/:userId/habit", (req, res, next) => {
   console.log(req);

--- a/routes/middleware/verifyGoogleIdToken.js
+++ b/routes/middleware/verifyGoogleIdToken.js
@@ -4,17 +4,15 @@ const createError = require("http-errors");
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 const verifyGoogleIdToken = async (req, res, next) => {
-  const { authorization } = req.headers;
-
-  if (!authorization) {
-    const error = createError(401, { message: "Unauthorized" });
+  const { idToken } = req.body;
+  
+  if (!idToken) {
+    const error = createError(400, { message: "Bad request" });
     next(error);
-    
+
     return;
   }
 
-  const idToken = authorization.split(" ")[1];
-  
   try {
     const ticket = await client.verifyIdToken({ idToken });
     const { email, name } = ticket.getPayload();

--- a/routes/middleware/verifyGoogleIdToken.js
+++ b/routes/middleware/verifyGoogleIdToken.js
@@ -1,13 +1,18 @@
 const { OAuth2Client } = require("google-auth-library");
 const createError = require("http-errors");
 
+const {
+  TOKEN_MESSAGE,
+  COMMON_MESSAGE,
+} = require("../../constants/dataValidationMessage");
+
 const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 const verifyGoogleIdToken = async (req, res, next) => {
   const { idToken } = req.body;
-  
+
   if (!idToken) {
-    const error = createError(400, { message: "Bad request" });
+    const error = createError(400, { message: TOKEN_MESSAGE.emptyTokenError });
     next(error);
 
     return;
@@ -16,12 +21,14 @@ const verifyGoogleIdToken = async (req, res, next) => {
   try {
     const ticket = await client.verifyIdToken({ idToken });
     const { email, name } = ticket.getPayload();
-    
+
     req.userInfo = { email, name };
 
     next();
-  } catch(err) {
-    const error = createError(400, err, { message: "Invalid Token" });
+  } catch (err) {
+    const error = createError(400, err, {
+      message: COMMON_MESSAGE.invalidServerError,
+    });
     next(error);
   }
 };

--- a/routes/middleware/verifyToken.js
+++ b/routes/middleware/verifyToken.js
@@ -1,5 +1,18 @@
 const jwt = require("jsonwebtoken");
+const createError = require("http-errors");
+
+const { TOKEN_MESSAGE } = require("../../constants/dataValidationMessage");
 
 const verifyToken = (req, res, next) => {
-  // 있으면 next() 넘겨주고..
+  const token = req.headers["authorization"].split(" ")[1];
+
+  try {
+    jwt.verify(token, process.env.SECRET_KEY);
+    next();
+  } catch (err) {
+    const error = createError(400, err, { message: TOKEN_MESSAGE.tokenError });
+    next(error);
+  }
 };
+
+module.exports = verifyToken;

--- a/routes/services/habit.js
+++ b/routes/services/habit.js
@@ -7,10 +7,22 @@ exports.getHabitList = async (userId) => {
     .populate("habits")
     .populate({
       path: "habits",
-      populate: { path: "catImage.catType"}
+      populate: { path: "catImage.catType" },
     });
 
-  // 여기서 클라이언트에서 렌더링하기 쉽게 내려받을 수 있도록 데이터 가공처리를 해주어야 한다.
-  console.log("habit 컨트롤러", targetUser.habits);
-  return targetUser;
+  const activeHabits = targetUser.habits
+    .filter((habit) => habit.isActive)
+    .map((activeHabit) => {
+      return {
+        id: activeHabit._id,
+        title: activeHabit.title,
+        endDate: activeHabit.endDate,
+        catImage:
+          activeHabit.catImage.catType.catStatusList[
+            activeHabit.catImage.catStatus
+          ],
+      };
+    });
+
+  return activeHabits;
 };

--- a/routes/services/habit.js
+++ b/routes/services/habit.js
@@ -1,0 +1,16 @@
+const User = require("../../models/User");
+const Habit = require("../../models/Habit");
+const CatImage = require("../../models/CatImage");
+
+exports.getHabitList = async (userId) => {
+  const targetUser = await User.findById(userId)
+    .populate("habits")
+    .populate({
+      path: "habits",
+      populate: { path: "catImage.catType"}
+    });
+
+  // 여기서 클라이언트에서 렌더링하기 쉽게 내려받을 수 있도록 데이터 가공처리를 해주어야 한다.
+  console.log("habit 컨트롤러", targetUser.habits);
+  return targetUser;
+};

--- a/routes/services/habit.js
+++ b/routes/services/habit.js
@@ -3,6 +3,8 @@ const Habit = require("../../models/Habit");
 const CatImage = require("../../models/CatImage");
 
 exports.getHabitList = async (userId) => {
+  const currentDate = new Date();
+
   const targetUser = await User.findById(userId)
     .populate("habits")
     .populate({
@@ -11,12 +13,17 @@ exports.getHabitList = async (userId) => {
     });
 
   const activeHabits = targetUser.habits
-    .filter((habit) => habit.isActive)
+    .filter(
+      (habit) =>
+        new Date(habit.dateList[habit.dateList.length - 1].date) -
+          currentDate >=
+        60 * 60 * 24 * 1000
+    )
     .map((activeHabit) => {
       return {
         id: activeHabit._id,
         title: activeHabit.title,
-        endDate: activeHabit.endDate,
+        endDate: activeHabit.dateList[activeHabit.dateList.length - 1].date,
         catImage:
           activeHabit.catImage.catType.catStatusList[
             activeHabit.catImage.catStatus

--- a/routes/services/habit.js
+++ b/routes/services/habit.js
@@ -13,12 +13,16 @@ exports.getHabitList = async (userId) => {
     });
 
   const activeHabits = targetUser.habits
-    .filter(
-      (habit) =>
+    .filter((habit) => {
+      return (
         new Date(habit.dateList[habit.dateList.length - 1].date) -
           currentDate >=
-        60 * 60 * 24 * 1000
-    )
+          60 * 60 * 24 * 1000 ||
+        currentDate -
+          new Date(habit.dateList[habit.dateList.length - 1].date) <=
+          2 * 60 * 60 * 24 * 1000
+      );
+    })
     .map((activeHabit) => {
       return {
         id: activeHabit._id,

--- a/routes/services/habit.js
+++ b/routes/services/habit.js
@@ -21,6 +21,7 @@ exports.getHabitList = async (userId) => {
           activeHabit.catImage.catType.catStatusList[
             activeHabit.catImage.catStatus
           ],
+        status: activeHabit.catImage.catStatus,
       };
     });
 

--- a/routes/services/habit.js
+++ b/routes/services/habit.js
@@ -2,6 +2,8 @@ const User = require("../../models/User");
 const Habit = require("../../models/Habit");
 const CatImage = require("../../models/CatImage");
 
+const { TIME_NUMBERS } = require("../../constants/numbers");
+
 exports.getHabitList = async (userId) => {
   const currentDate = new Date();
 
@@ -17,10 +19,10 @@ exports.getHabitList = async (userId) => {
       return (
         new Date(habit.dateList[habit.dateList.length - 1].date) -
           currentDate >=
-          60 * 60 * 24 * 1000 ||
+          TIME_NUMBERS.checkTimeForActiveness ||
         currentDate -
           new Date(habit.dateList[habit.dateList.length - 1].date) <=
-          2 * 60 * 60 * 24 * 1000
+          2 * TIME_NUMBERS.checkTimeForActiveness
       );
     })
     .map((activeHabit) => {


### PR DESCRIPTION
# [3] {feat: 메인페이지 렌더링을 위한 습관데이터 get 요청 처리}

## 노션 칸반 링크
- [습관데이터 get 요청 처리](https://www.notion.so/jsok79/33c35c40538b40b8a4f3c620316b4fd4?v=9f7eab84b0104769824b6b70f34ec8ea&p=fcb679f8172345e698dd1427090ad26c)
​
## 카드에서 구현 혹은 해결하려는 내용
- 클라이언트로부터 get 요청 응답 데이터 전달 
  - 기존 스키마 구조에 있던 isActive, endDate는 삭제처리하고, 원래 저장되어있던 dateList에서 정보를 사용
  - isActive의 경우, 서버에 요청한 일자와 데이터상에 저장되어있는 endDate의 비교를 통해 분기처리 
  - 이미 종료된 습관이라 하더라도, 종료되었음을 보여주어야 하기 때문에 추가 분기처리가 필요했음
- verifyToken 미들웨어 구현
- 기타 상수처리 
​