### PR TITLE
Feature/11

### DIFF
--- a/models/sampleHabit.json
+++ b/models/sampleHabit.json
@@ -1,82 +1,1377 @@
 [
   {
-    "author": "621a78a7725ac002636cf6c6",
-    "title": "물 800ml 마시기",
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-1)",
     "dateList": [
       {
-        "date": "2022-02-25T00:00:00.099Z",
-        "isChecked": false
-      },
-      {
-        "date": "2022-02-26T00:00:00.099Z",
+        "date": "2022-02-26T00:00:00.638Z",
         "isChecked": true
       },
       {
-        "date": "2022-02-27T00:00:00.099Z",
+        "date": "2022-02-27T00:00:00.638Z",
         "isChecked": true
       },
       {
-        "date": "2022-02-28T00:00:00.099Z",
+        "date": "2022-02-28T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-03-01T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-03-02T00:00:00.638Z",
         "isChecked": false
       },
       {
-        "date": "2022-03-01T00:00:00.099Z",
+        "date": "2022-03-03T00:00:00.638Z",
         "isChecked": false
       },
       {
-        "date": "2022-03-02T00:00:00.099Z",
-        "isChecked": false
-      },
-      {
-        "date": "2022-03-03T00:00:00.099Z",
-        "isChecked": false
+        "date": "2022-03-04T00:00:00.638Z",
+        "isChecked": true
       }
     ],
-    "endDate": "2022-03-03T00:00:00.099Z",
     "catImage": {
-      "catType": "621bbb3c2a3a3ca6871c6e22",
-      "catStatus": 2
-    },
-    "isActive": true
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 5
+    }
   },
   {
-    "author": "621a78a7725ac002636cf6c6",
-    "title": "비타민D 약 먹기",
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-2)",
     "dateList": [
       {
-        "date": "2022-02-01T00:00:00.099Z",
+        "date": "2022-02-25T00:00:00.638Z",
         "isChecked": true
       },
       {
-        "date": "2022-02-02T00:00:00.099Z",
-        "isChecked": false
-      },
-      {
-        "date": "2022-02-03T00:00:00.099Z",
+        "date": "2022-02-26T00:00:00.638Z",
         "isChecked": true
       },
       {
-        "date": "2022-02-04T00:00:00.099Z",
-        "isChecked": false
-      },
-      {
-        "date": "2022-02-05T00:00:00.099Z",
-        "isChecked": false
-      },
-      {
-        "date": "2022-02-06T00:00:00.099Z",
+        "date": "2022-02-27T00:00:00.638Z",
         "isChecked": true
       },
       {
-        "date": "2022-02-07T00:00:00.099Z",
+        "date": "2022-02-28T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-03-01T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-03-02T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-03-03T00:00:00.638Z",
         "isChecked": true
       }
     ],
-    "endDate": "2022-02-07T00:00:00.099Z",
     "catImage": {
-      "catType": "621bbb3c2a3a3ca6871c6e24",
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6c"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-3)",
+    "dateList": [
+      {
+        "date": "2022-02-24T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-25T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-26T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-27T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-28T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-03-01T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-03-02T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6b"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-4)",
+    "dateList": [
+      {
+        "date": "2022-02-23T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-24T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-25T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-26T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-27T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-28T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-03-01T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6e"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-5)",
+    "dateList": [
+      {
+        "date": "2022-02-22T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-23T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-24T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-25T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-26T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-27T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-28T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6a"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-6)",
+    "dateList": [
+      {
+        "date": "2022-02-21T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-22T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-23T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-24T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-25T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-26T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-27T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6a"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-7)",
+    "dateList": [
+      {
+        "date": "2022-02-20T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-21T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-22T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-23T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-24T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-25T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-26T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6e"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-8)",
+    "dateList": [
+      {
+        "date": "2022-02-19T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-20T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-21T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-22T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-23T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-24T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-25T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 6
+    },
+    "__v": 0
+  },
+    {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-9)",
+    "dateList": [
+      {
+        "date": "2022-02-18T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-19T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-20T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-21T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-22T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-23T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-24T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6e"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-10)",
+    "dateList": [
+      {
+        "date": "2022-02-17T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-18T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-19T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-20T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-21T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-22T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-23T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6e"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-11)",
+    "dateList": [
+      {
+        "date": "2022-02-16T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-17T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-18T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-19T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-20T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-21T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-22T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6b"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-12)",
+    "dateList": [
+      {
+        "date": "2022-02-15T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-16T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-17T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-18T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-19T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-20T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-21T00:00:00.638Z",
+        "isChecked": false
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 2
+    },
+    "__v": 0
+  },
+    {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-13)",
+    "dateList": [
+      {
+        "date": "2022-02-14T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-15T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-16T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-17T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-18T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-19T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-20T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6c"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-14)",
+    "dateList": [
+      {
+        "date": "2022-02-13T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-14T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-15T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-16T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-17T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-18T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-19T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6e"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-15)",
+    "dateList": [
+      {
+        "date": "2022-02-12T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-13T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-14T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-15T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-16T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-17T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-18T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6f"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-16)",
+    "dateList": [
+      {
+        "date": "2022-02-11T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-12T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-13T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-14T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-15T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-16T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-17T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6b"
+      },
+      "catStatus": 6
+    },
+    "__v": 0
+  },
+    {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-17)",
+    "dateList": [
+      {
+        "date": "2022-02-10T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-11T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-12T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-13T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-14T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-15T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-16T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6c"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-18)",
+    "dateList": [
+      {
+        "date": "2022-02-09T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-10T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-11T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-12T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-13T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-14T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-15T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6e"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-19)",
+    "dateList": [
+      {
+        "date": "2022-02-08T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-09T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-10T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-11T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-12T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-13T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-14T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6b"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-20)",
+    "dateList": [
+      {
+        "date": "2022-02-07T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-08T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-09T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-10T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-11T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-12T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-13T00:00:00.638Z",
+        "isChecked": false
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6a"
+      },
       "catStatus": 4
     },
-    "isActive": false
+    "__v": 0
+  },
+    {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-21)",
+    "dateList": [
+      {
+        "date": "2022-02-06T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-07T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-08T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-09T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-10T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-11T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-12T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-22)",
+    "dateList": [
+      {
+        "date": "2022-02-05T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-06T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-07T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-08T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-09T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-10T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-11T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6e"
+      },
+      "catStatus": 3
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-23)",
+    "dateList": [
+      {
+        "date": "2022-02-04T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-05T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-06T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-07T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-08T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-09T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-10T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-24)",
+    "dateList": [
+      {
+        "date": "2022-02-03T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-04T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-05T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-06T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-07T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-08T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-09T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 6
+    },
+    "__v": 0
+  },
+    {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-25)",
+    "dateList": [
+      {
+        "date": "2022-02-02T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-03T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-04T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-05T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-06T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-07T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-08T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6f"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-26)",
+    "dateList": [
+      {
+        "date": "2022-02-01T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-02T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-03T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-04T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-05T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-06T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-07T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6c"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-27)",
+    "dateList": [
+      {
+        "date": "2022-01-31T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-01T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-02T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-03T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-04T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-05T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-06T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6b"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-28)",
+    "dateList": [
+      {
+        "date": "2022-01-30T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-31T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-01T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-02T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-03T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-04T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-05T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 4
+    },
+    "__v": 0
+  },
+    {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-29)",
+    "dateList": [
+      {
+        "date": "2022-01-29T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-30T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-31T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-01T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-02T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-03T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-04T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6c"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-30)",
+    "dateList": [
+      {
+        "date": "2022-01-28T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-29T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-30T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-31T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-01T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-02T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-03T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6a"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-31)",
+    "dateList": [
+      {
+        "date": "2022-01-27T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-28T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-29T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-30T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-31T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-01T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-02-02T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 5
+    },
+    "__v": 0
+  },
+  {
+    "author": {
+      "$oid": "621a78a7725ac002636cf6c6"
+    },
+    "title": "렌더링 테스트(실패-32)",
+    "dateList": [
+      {
+        "date": "2022-01-26T00:00:00.638Z",
+        "isChecked": false
+      },
+      {
+        "date": "2022-01-27T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-28T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-29T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-30T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-01-31T00:00:00.638Z",
+        "isChecked": true
+      },
+      {
+        "date": "2022-02-01T00:00:00.638Z",
+        "isChecked": true
+      }
+    ],
+    "catImage": {
+      "catType": {
+        "$oid": "6220cd58c5cccc2aa1b62a6d"
+      },
+      "catStatus": 6
+    },
+    "__v": 0
   }
 ]

--- a/routes/controllers/habit.js
+++ b/routes/controllers/habit.js
@@ -19,11 +19,22 @@ exports.getHabitList = async (req, res, next) => {
   }
 
   try {
-    const targetHabitList = await habitService.getHabitList(userId);
+    if (!Object.keys(req.query).length) {
+      const targetHabitList = await habitService.getHabitList(userId);
 
-    res.json({
-      habitList: targetHabitList,
-    });
+      res.json({
+        habitList: targetHabitList,
+      });
+    } else {
+      const { limit, status, localTime, page } = req.query;
+      const { expiredHabitList, nextPage } =
+        await habitService.getExpiredHabitList(userId, limit, status, localTime, page);
+
+      res.json({
+        habitList: expiredHabitList,
+        nextPage,
+      });
+    }
   } catch (err) {
     const error = createError(500, err, {
       message: COMMON_MESSAGE.invalidServerError,

--- a/routes/services/habit.js
+++ b/routes/services/habit.js
@@ -36,8 +36,6 @@ exports.getExpiredHabitList = async (
   localTime,
   page
 ) => {
-  console.log("heelllllo");
-  
   const targetUser = await User.findById(userId)
     .populate("habits")
     .populate({


### PR DESCRIPTION
# [11] {feat: 마이페이지 GET 요청 작업}

## 노션 칸반 링크
- [마이페이지 GET 요청 작업](https://www.notion.so/jsok79/33c35c40538b40b8a4f3c620316b4fd4?v=9f7eab84b0104769824b6b70f34ec8ea&p=29fdef38d2f34648b8d862406f376a7d)
​
## 카드에서 구현 혹은 해결하려는 내용
- 기존 `users/:userId` 백엔드 엔드포인트 내 쿼리스트링으로 분기처리하여 데이터 처리
  - limit(내보내는 데이터 개수), status (마이페이지 내 성공, 실패 분기처리용), page (useInfiniteQuery의 pageParams)
​